### PR TITLE
Fix issues for compilation with SDL library

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This window needs to becurrently focused, otherwise this node will not receive a
 3. Clone this repository
   - (ssh) `$ git clone git@github.com:cmower/ros2-keyboard.git`
   - (https) `$ git clone https://github.com/cmower/ros2-keyboard.git`
-4. Install SDL, see [here](https://gist.github.com/cmower/5d3ad491c2acf447b7f4c307d5f88313).
+4. Install SDL 1.2 with the command `sudo apt install libsdl1.2-dev`.
 5. `$ cd /path/to/your_ws`
 6. `$ colcon build`
 

--- a/keyboard/CMakeLists.txt
+++ b/keyboard/CMakeLists.txt
@@ -19,9 +19,10 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(SDL REQUIRED)
 find_package(keyboard_msgs REQUIRED)
 
-set(LIBS ${SDL_LIBRARY})
+set(LIBS ${SDL_LIBRARY} SDL::SDL)
 include_directories(${SDL_INCLUDE_DIR})
 
 add_executable(keyboard src/keyboard.cpp)


### PR DESCRIPTION
This PR fixes some issues with respect to the SDL library:

1. The code requires SDL 1.2. SDL 2 or SDL 3 do not work. For example `SDL_SetVideoMode` is not present in SDL 2. However, the current README was pointing to a guide for installing SDL 2.
2. There were some issues when running `colcon build` as it didn't find the installed SDL library. This is fixed by adding the `find_package(SDL REQUIRED)` command