### PR TITLE
Use execdep to declare the dependency on SDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This window needs to becurrently focused, otherwise this node will not receive a
 3. Clone this repository
   - (ssh) `$ git clone git@github.com:cmower/ros2-keyboard.git`
   - (https) `$ git clone https://github.com/cmower/ros2-keyboard.git`
-4. Install SDL 1.2 with the command `sudo apt install libsdl1.2-dev`.
-5. `$ cd /path/to/your_ws`
+4. `$ cd /path/to/your_ws`
+5. Install SDL 1.2 with the command, `$ rosdep install --from-paths src --ignore-src`.
 6. `$ colcon build`
 
 # Nodes

--- a/keyboard/package.xml
+++ b/keyboard/package.xml
@@ -14,7 +14,7 @@
   <license>GPLv2</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
+  <exec_depend>sdl</exec_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/keyboard_msgs/package.xml
+++ b/keyboard_msgs/package.xml
@@ -16,6 +16,7 @@
 
   <build_depend>rosidl_default_generators</build_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>sdl</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <depend>std_msgs</depend>


### PR DESCRIPTION
This is a great tool, thanks a lot! I Just have a little quality of life suggestion.

Rather than manually install libsdl, you can use the native ros packaging system to declare it and install it. This is pretty handy when for example:

- you're setting up a lot of ros packages in your workspace at the same time, since `rosdep` can fetch and install all of them at once
- you're targeting a platform that isn't ubuntu/debian, and you want to get the [right package name](https://github.com/ros/rosdistro/blob/58b55ba9a9feabd9c7604c290dd6a75df7fad175/rosdep/base.yaml#L8272) there too.

Cheers, Robin